### PR TITLE
修复copy_headers的两个异常情况

### DIFF
--- a/cocoapods-imy-bin/lib/cocoapods-imy-bin/helpers/build_utils.rb
+++ b/cocoapods-imy-bin/lib/cocoapods-imy-bin/helpers/build_utils.rb
@@ -14,6 +14,22 @@ module CBin
         return Utils.is_swift_module(spec)
       end
 
+      def Utils.spec_header_dir(spec)
+        spec_header_dir = "./Headers/Public/#{spec.name}"
+
+        unless File.exist?(spec_header_dir)
+          spec_header_dir = "./Pods/Headers/Public/#{spec.name}"
+        end
+
+        unless File.exist?(spec_header_dir)
+          # 一些库名称中使用了中划线如AAA-BBB，public header中库名称会默认处理成下划线AAA_BBB
+          module_name = spec.name.gsub("-", "_")
+          spec_header_dir = "./Pods/Headers/Public/#{module_name}"
+        end
+
+        spec_header_dir
+      end
+
       def Utils.is_swift_module(spec)
 
         is_framework = false
@@ -21,12 +37,7 @@ module CBin
         #auto 走这里
         if File.exist?(dir)
           Dir.chdir(dir) do
-            public_headers = Array.new
-            spec_header_dir = "./Headers/Public/#{spec.name}"
-
-            unless File.exist?(spec_header_dir)
-              spec_header_dir = "./Pods/Headers/Public/#{spec.name}"
-            end
+            spec_header_dir = Utils.spec_header_dir(spec)
             return false unless File.exist?(spec_header_dir)
 
             is_framework = File.exist?(File.join(spec_header_dir, "#{spec.name}-umbrella.h"))

--- a/cocoapods-imy-bin/lib/cocoapods-imy-bin/helpers/framework_builder.rb
+++ b/cocoapods-imy-bin/lib/cocoapods-imy-bin/helpers/framework_builder.rb
@@ -217,11 +217,9 @@ module CBin
 
         #by slj 如果没有头文件，去 "Headers/Public"拿
         # if public_headers.empty?
-        spec_header_dir = "./Headers/Public/#{@spec.name}"
-        unless File.exist?(spec_header_dir)
-          spec_header_dir = "./Pods/Headers/Public/#{@spec.name}"
-        end
+        spec_header_dir = CBin::Build::Utils.spec_header_dir(@spec)
         raise "copy_headers #{spec_header_dir} no exist " unless File.exist?(spec_header_dir)
+
         Dir.chdir(spec_header_dir) do
           headers = Dir.glob('*.h')
           headers.each do |h|
@@ -253,6 +251,13 @@ module CBin
             module * { export * }
           }
           MAP
+        else
+          # by ChildhoodAndy
+          # try to read modulemap file from public header
+          module_map_file = File.join(spec_header_dir, "#{@spec.name}.modulemap")
+          if Pathname(module_map_file).exist?
+            module_map = File.read(module_map_file)
+          end
         end
 
         unless module_map.nil?


### PR DESCRIPTION
1. 库名称中含有中划线导致头文件找不到的问题修复 
一些库名称中使用了中划线如AAA-BBB，public header中库名称会默认处理成下划线AAA_BBB

2. 完善modulemap生成

- `!@spec.module_map.nil?` 不满足
- `public_headers.map(&:basename).map(&:to_s).include?("#{@spec.name}.h")`

在上述两种情况仍然不满足的情况下，可以读取`Headers/Public/XXX.modulemap`文件内容
