### PR TITLE
fix: multiple dependencies error

### DIFF
--- a/cocoapods-imy-bin/lib/cocoapods-imy-bin/command/bin/update.rb
+++ b/cocoapods-imy-bin/lib/cocoapods-imy-bin/command/bin/update.rb
@@ -111,9 +111,12 @@ module Pod
                         end
 
                         target_dependencies.each do |target_dependency|
-                          next unless target_dependency.is_a?(Hash) &&
-                                      target_dependency.keys.first &&
-                                      target_dependency.keys.first == local_dependency.keys.first
+                          dp_hash_equal = target_dependency.is_a?(Hash) &&
+                            target_dependency.keys.first &&
+                            target_dependency.keys.first == local_dependency.keys.first
+                          dp_str_equal = target_dependency.is_a?(String) &&
+                            target_dependency == local_dependency.keys.first
+                          next unless dp_hash_equal || dp_str_equal
 
                           target_dependencies.delete target_dependency
                           break


### PR DESCRIPTION
## Podfile
```ruby
target 'Demo' do
  pod 'Masonry'
end
```

## Podfile_local
```ruby
plugin 'cocoapods-imy-bin'
use_binaries!

target 'Demo' do
  
    pod 'Masonry', :path => '~/ZZPods/zz-ios-open/Masonry'

end
```

`pod bin install`后执行报错：

```bash
[!] There are multiple dependencies with different sources for `Masonry` in `Podfile`:

- Masonry
- Masonry (from `~/ZZPods/zz-ios-open/Masonry`)
```

![image](https://user-images.githubusercontent.com/1892303/104432526-12a9c900-55c4-11eb-8f66-bea5e766bf8d.png)

Podfile中的 `pod 'Masonry'`得到的`target_dependency`此时是一个`String`类型（当后面有版本, :git, :podspec等时为Hash类型）, 此时`target_dependencies.delete target_dependency`无法删除，导致两个库重复报错。
