### PR TITLE
Fix none exist command

### DIFF
--- a/cocoapods-imy-bin/lib/cocoapods-imy-bin/command/bin.rb
+++ b/cocoapods-imy-bin/lib/cocoapods-imy-bin/command/bin.rb
@@ -34,8 +34,6 @@ module Pod
       include CBin::SpecFilesHelper
 
       self.abstract_command = true
-
-      self.default_subcommand = 'open'
       self.summary = '组件二进制化插件.'
       self.description = <<-DESC
         组件二进制化插件。利用源码私有源与二进制私有源实现对组件依赖类型的切换。


### PR DESCRIPTION
`self.default_subcommand = 'open'`来自`cocoapods-bin`项目，imy-bin没有open命令，故删除。不然`pod bin --help`也会报`open`命令不存在的错误。