### PR TITLE
Fix build type

### DIFF
--- a/cocoapods-imy-bin/lib/cocoapods-imy-bin/native/podfile_generator.rb
+++ b/cocoapods-imy-bin/lib/cocoapods-imy-bin/native/podfile_generator.rb
@@ -35,7 +35,7 @@ module Pod
             plugin(*[name, options].compact)
           end
 
-          use_frameworks!(generator.configuration.use_frameworks?)
+          use_frameworks!(generator.use_frameworks_value)
 
           if (supported_swift_versions = generator.supported_swift_versions)
             supports_swift_versions(supported_swift_versions)


### PR DESCRIPTION
# podspec
```ruby
...
  s.dependency 'SDWebImage'
  s.dependency 'SDWebImageFLPlugin'
  s.dependency 'SDWebImageWebPCoder'
end
```

# podfile
```ruby
target 'Demo' do
  pod 'SDWebImage'
  pod 'SDWebImageWebPCoder'
  pod 'SDWebImageFLPlugin'
  pod 'FLAnimatedImage'
end
```

出现了 build-arch目录下 全部是动态库的问题 https://github.com/MeetYouDevs/cocoapods-imy-bin/issues/93#issuecomment-759963867

![image](https://user-images.githubusercontent.com/1892303/104574149-ae087000-5690-11eb-8702-26e4d57b6b09.png)

之前的写法

```ruby
# cocoapods-core/podfile/target_definition.rb

      def use_frameworks!(option = true)
        value = case option
                when true, false
                  option ? BuildType.dynamic_framework : BuildType.static_library
                when Hash
                  BuildType.new(:linkage => option.fetch(:linkage), :packaging => :framework)
                else
                  raise ArgumentError, "Got `#{option.inspect}`, should be a boolean or hash."
                end
        set_hash_value('uses_frameworks', value.to_hash)
      end
```
误设置true导致走了 BuildType.dynamic_framework。

修改成官方写法会更严谨。（cocoapods-generate库 generate/podfile_generator.rb)