### PR TITLE
Fix lib name

### DIFF
--- a/cocoapods-imy-bin/lib/cocoapods-imy-bin/helpers/framework_builder.rb
+++ b/cocoapods-imy-bin/lib/cocoapods-imy-bin/helpers/framework_builder.rb
@@ -106,7 +106,7 @@ module CBin
 
         # if is_debug_model
           libs = (ios_architectures + ios_architectures_sim) .map do |arch|
-            library = "build-#{arch}/lib#{target_name}.a"
+            library = "build-#{arch}/lib#{@spec.name}.a"
             library
           end
         # else


### PR DESCRIPTION
xcode build出来的lib名称为libXXX.a的形式不带平台后缀，这里不能使用带平台名称的静态库名字去查找。